### PR TITLE
Fixed for parsing command line arguments

### DIFF
--- a/bin/perl-build
+++ b/bin/perl-build
@@ -20,10 +20,10 @@ GetOptions(
     'U=s@' => \@U,
 );
 for (@D, @A, @U) {
-    for (@_) {
-        s/^=//;
-    }
+    s/^=//;
 }
+
+shift @ARGV if @ARGV >= 1 && $ARGV[0] eq '--';
 
 my $stuff   = shift @ARGV or pod2usage();
 my $dest    = shift @ARGV or pod2usage();


### PR DESCRIPTION
日本語で恐縮ですが、D, A, Uのフラグに関するコマンドラインオプションに
ついて先頭の '='を取り除くループが意味をなしていないように思えます。
なおこれは plenvでも見られました。

あと Getopt::Longの pass_throughオプションを指定しているため、
'--'をつけた場合, それが ARGVに含まれてしまいます。なので、

```
perl-build -Dusethreads -- 5.16.2 /usr/local/perl-5.16.2
```

のような実行を行うと、stuffが '--', destが 5.16.2と設定されてしまいます。

ついでにですが、トップの README.podのリンク先が存在しないファイルに
なっており、プロジェクトのトップページでドキュメントが見れなくなって
います。

ご確認のほどよろしくお願いします。
