### PR TITLE
Introducing perlstrip

### DIFF
--- a/author/fatpack.pl
+++ b/author/fatpack.pl
@@ -6,6 +6,11 @@ export PERL5LIB=`dirname $0`/../lib/
 fatpack trace $SRC
 fatpack packlists-for `cat fatpacker.trace` >packlists
 fatpack tree `cat packlists`
+
+if type perlstrip >/dev/null 2>&1; then
+    find fatlib -type f -name '*.pm' | xargs -n1 perlstrip -s
+fi
+
 (echo "#!/usr/bin/env perl"; fatpack file; cat $SRC) > $DST
 chmod +x $DST
 


### PR DESCRIPTION
Regarding #11 , e677ce618e5fddb3ab804c99f793bc56ba9602c1 is an tentative commit for introducing perlstrip before fatpacking  

It should also work if perlstrip is not installed, and optionally use it only if it is installed.

For the record, this reduce perl-build from 1736KB to 500KB

```
 \ls -1ks perl-build*
 500 perl-build
1736 perl-build-original
```
