### PR TITLE
change /usr/bin/perl to $^X

### DIFF
--- a/bin/plenv-install
+++ b/bin/plenv-install
@@ -74,7 +74,7 @@ sub main {
     mkpath($build_dir);
 
     system(
-        '$^X',
+        $^X,
         '--',
         $PERL_BUILD,
         '--symlink-devel-executables',


### PR DESCRIPTION
/usr/bin/perl以外にperl本体があった場合にうまく動かなかったので修正させていただきました
