### PR TITLE
use perl-releases page instead of scraping search.cpan.org

### DIFF
--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -15,6 +15,7 @@ use File::Temp;
 use HTTP::Tiny;
 use Devel::PatchPerl 0.88;
 use Perl::Build::Built;
+use Time::Local;
 
 our $CPAN_MIRROR = $ENV{PERL_BUILD_CPAN_MIRROR} || 'http://search.cpan.org/CPAN';
 
@@ -60,29 +61,87 @@ sub extract_tarball {
 sub perl_release {
     my ($class, $version) = @_;
 
-    # TODO: switch to metacpan API?
+    my ($dist_tarball, $dist_tarball_url);
+    for my $func (qw/cpan_perl_releases perl_releases_page search_cpan_org/) {
+        eval {
+            ($dist_tarball, $dist_tarball_url) = $class->can("perl_release_by_$func")->($class,$version);
+        };
+        warn "WARN: [$func] $@" if $@;
+        last if $dist_tarball && $dist_tarball_url;
+    }
+    die "ERROR: Cannot find the tarball for perl-$version\n"
+        if !$dist_tarball and !$dist_tarball_url;
+           
+    return ($dist_tarball, $dist_tarball_url);
+}
+
+sub perl_release_by_cpan_perl_releases {
+    my ($class, $version) = @_;
     my $tarballs = CPAN::Perl::Releases::perl_tarballs($version);
 
     my $x = (values %$tarballs)[0];
+    die "not found the tarball for perl-$version\n" unless $x;
+    my $dist_tarball = (split("/", $x))[-1];
+    my $dist_tarball_url = $CPAN_MIRROR . "/authors/id/$x";
+    return ($dist_tarball, $dist_tarball_url);
+}
 
-    if ($x) {
-        my $dist_tarball = (split("/", $x))[-1];
-        my $dist_tarball_url = $CPAN_MIRROR . "/authors/id/$x";
-        return ($dist_tarball, $dist_tarball_url);
+sub perl_release_by_perl_releases_page {
+    my ($class, $version) = @_;
+
+    my $url = "http://perl-releases.s3-website-us-east-1.amazonaws.com/";
+    my $http = HTTP::Tiny->new();
+    my $response = $http->get($url);
+    if (!$response->{success}) {
+        die "Cannot get content from $url: $response->{status} $response->{reason}\n";
     }
-    my $tsv = http_get("http://perl-releases.s3-website-us-east-1.amazonaws.com/");
 
-    unless ($tsv) {
-        die "ERROR: Failed to download perl-${version} tarball.";
+    if ( ! exists $response->{headers}{'last-modified'} ) {
+        die "There is not Last-Modified header. ignore this response\n";
+    }
+
+    my $last_modified;
+    # Copy from HTTP::Tiny::_parse_date_time
+    my $MoY = "Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec";
+    if ( $response->{headers}{'last-modified'} =~ 
+             /^[SMTWF][a-z]+, +(\d{1,2}) ($MoY) +(\d\d\d\d) +(\d\d):(\d\d):(\d\d) +GMT$/) {
+        my @tl_parts = ($6, $5, $4, $1, (index($MoY,$2)/4), $3);
+        $last_modified = eval {
+            my $t = @tl_parts ? Time::Local::timegm(@tl_parts) : -1;
+            $t < 0 ? undef : $t;
+        };
+    }
+    if ( ! defined $last_modified || time - $last_modified > 3*86400 ) { #parse error or 3days old
+        die "This page is 3 or more days old. ignore\n";
     }
 
     my ($dist_path, $dist_tarball) =
-        $tsv =~ m[^\Q${version}\E\t(.+?/(perl-${version}.tar.(gz|bz2)))]m;
-    die "ERROR: Cannot find the tarball for perl-$version\n"
+        $response->{content} =~ m[^\Q${version}\E\t(.+?/(perl-${version}.tar.(gz|bz2)))]m;
+    die "not found the tarball for perl-$version\n"
         if !$dist_path and !$dist_tarball;
     my $dist_tarball_url = "$CPAN_MIRROR/authors/id/${dist_path}";
     return ($dist_tarball, $dist_tarball_url);
+
 }
+
+sub perl_release_by_search_cpan_org {
+    my ($class, $version) = @_;
+
+    my $html = http_get("http://search.cpan.org/dist/perl-${version}");
+
+    unless ($html) {
+        die "Failed to download perl-${version} tarball\n";
+    }
+
+    my ($dist_path, $dist_tarball) =
+        $html =~ m[<a href="/CPAN/(authors/id/.+/(perl-${version}.tar.(gz|bz2)))">Download</a>];
+    die "not found the tarball for perl-$version\n"
+        if !$dist_path and !$dist_tarball;
+    my $dist_tarball_url = "$CPAN_MIRROR/${dist_path}";
+    return ($dist_tarball, $dist_tarball_url);
+
+}
+
 
 sub http_get {
     my ($url) = @_;
@@ -92,7 +151,7 @@ sub http_get {
     if ($response->{success}) {
         return $response->{content};
     } else {
-        return "Cannot get content from $url: $response->{status} $response->{reason}";
+        die "Cannot get content from $url: $response->{status} $response->{reason}\n";
     }
 }
 

--- a/t/02_perl_release.t
+++ b/t/02_perl_release.t
@@ -19,7 +19,7 @@ subtest 'CPAN::Perl::Releases' => sub {
     }
 };
 
-subtest 'perl-releases api' => sub {
+subtest 'perl-releases-page' => sub {
     plan skip_all => 'author test only' unless $ENV{AUTHOR_TESTING};
     local $Perl::Build::CPAN_MIRROR = '';
     no warnings 'redefine';
@@ -29,5 +29,22 @@ subtest 'perl-releases api' => sub {
         like ($url, qr!^/authors/id/\Q$test{$ver}\E!);
     }
 };
+
+subtest 'search.cpan.org' => sub {
+    plan skip_all => 'author test only' unless $ENV{AUTHOR_TESTING};
+    local $Perl::Build::CPAN_MIRROR = '';
+    no warnings 'redefine';
+    *{CPAN::Perl::Releases::perl_tarballs} = sub {};
+    my $orig = HTTP::Tiny->can('get');
+    *{HTTP::Tiny::get} = sub {
+        return {success=>0,status=>599,reason=>"test error"} if $_[1] =~ m!perl-releases\.!;
+        $orig->(@_);
+    };
+    for my $ver (keys %test ) {
+        my ($tarball,$url) = Perl::Build->perl_release($ver);
+        like ($url, qr!^/authors/id/\Q$test{$ver}\E!);
+    }
+};
+
 
 done_testing;


### PR DESCRIPTION
I made perl-releases page (http://perl-releases.s3-website-us-east-1.amazonaws.com/)
This page is generated by https://github.com/kazeburo/perl-releases-list and hosted on Amazon S3.

In perl_release(), use this perl-release page instead of accessing to search.cpan.org. It's lighter than scraping search.cpan.org and has high availability.
