### PR TITLE
change default cpan mirror to www.cpan.org

### DIFF
--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -16,7 +16,7 @@ use HTTP::Tiny;
 use Devel::PatchPerl 0.88;
 use Perl::Build::Built;
 
-our $CPAN_MIRROR = $ENV{PERL_BUILD_CPAN_MIRROR} || 'http://search.cpan.org/CPAN';
+our $CPAN_MIRROR = $ENV{PERL_BUILD_CPAN_MIRROR} || 'http://www.cpan.org';
 
 sub available_perls {
     my ( $class, $dist ) = @_;


### PR DESCRIPTION
change default cpan mirror from search.cpan.org to www.cpan.org.
recently, search.cpan.org often is down, and downtime is long. cpanm uses www.cpan.org
