### PR TITLE
install blead from github archive

### DIFF
--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -55,7 +55,11 @@ sub extract_tarball {
     system($extract_command) == 0
         or die "Failed to extract $dist_tarball";
     $dist_tarball =~ s{(?:.*/)?([^/]+)\.tar\.(?:gz|bz2)$}{$1};
-    return "$destdir/$dist_tarball"; # Note that this is incorrect for blead
+    if ($dist_tarball eq 'blead') {
+        return catfile($destdir, "perl5-$dist_tarball");
+    } else {
+        return "$destdir/$dist_tarball"; # Note that this is incorrect for blead
+    }
 }
 
 sub perl_release {

--- a/script/perl-build
+++ b/script/perl-build
@@ -63,7 +63,19 @@ push @configure_options, map { "-U$_" } @U;
 
 $ENV{PERL5_PATCHPERL_PLUGIN} = $patches if defined $patches;
 
-if ($stuff =~ m{^http://}) {
+if ($stuff eq 'blead') {
+    my $url = "https://github.com/Perl/perl5/archive/blead.tar.gz";
+    Perl::Build->install_from_url(
+        $url => (
+            dst_path          => $dest,
+            configure_options => \@configure_options,
+            test              => $test,
+            build_dir         => $build_dir,
+            jobs              => $jobs,
+            tarball_dir       => $tarball_dir,
+        )
+    );
+} elsif ($stuff =~ m{^http://}) {
     Perl::Build->install_from_url(
         $stuff => (
             dst_path          => $dest,


### PR DESCRIPTION
I implemented it with git clone from http://perl5.git.perl.org/perl.git at first, but apparently it's easier to fetch a blead tarball from github archive.

I haven't updated pod yet.

Do we need to 1) list `blead` for `plenv install -l`, and 2) implement `plenv reinstall blead` ?
