### PR TITLE
Fix installing blead perl

### DIFF
--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -59,7 +59,7 @@ sub extract_tarball {
         opendir my $dh, $destdir or die "Can't open $destdir: $!";
         my $latest = [];
         while(my $dir = readdir $dh) {
-            next unless -d $dir && $dir =~ /perl-[0-9a-f]{7,8}$/;
+            next unless -d catfile($destdir, $dir) && $dir =~ /perl-[0-9a-f]{7,8}$/;
             my $mtime = (stat(_))[9];
             $latest = [$dir, $mtime] if !$latest->[1] or $latest->[1] < $mtime;
         }

--- a/script/perl-build
+++ b/script/perl-build
@@ -68,7 +68,7 @@ if ($stuff eq 'blead') {
     Perl::Build->install_from_url(
         $url => (
             dst_path          => $dest,
-            configure_options => \@configure_options,
+            configure_options => ['-Dusedevel', @configure_options],
             test              => $test,
             build_dir         => $build_dir,
             jobs              => $jobs,


### PR DESCRIPTION
- Fix condition. `$dir` is entry of `$destdir`, not current directory.
- Specify -Dusedevel option. Configure of blead perl fails without this option

This is related to #33.
CC: @charsbar 
