### PR TITLE
fix for issue #46 - the cpan version feed can come through without newlines

### DIFF
--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -32,11 +32,10 @@ sub available_perls {
     my @available_versions;
 
     my %uniq;
-    for ( split "\n", $html ) {
-        if (my ($version) = m|<a href="perl-(.+)\.tar\.gz">(.+?)</a>|) {
-            next if $uniq{$version}++;
-            push @available_versions, $version;
-        }
+    while ($html =~ m|<a href="perl-([^"]+)\.tar\.gz">(.+?)</a>|g) {
+        my $version = $1;
+        next if $uniq{$version}++;
+        push @available_versions, $version;
     }
 
     return @available_versions;


### PR DESCRIPTION
For whatever reason, I have seen the cpan version feed come through without newlines (possibly mobile operator interference), but IMO the 'scraping' code could be more robust to cope with this, and also variations in the HTML

the regex change is tuned to match the tarball