### PR TITLE
Remove RC version

### DIFF
--- a/t/02_perl_release.t
+++ b/t/02_perl_release.t
@@ -4,8 +4,8 @@ use Perl::Build;
 use CPAN::Perl::Releases;
 
 my %test = (
+    '5.22.1' => q!S/SH/SHAY/perl-5.22.1.tar.!,
     '5.18.2' => q!R/RJ/RJBS/perl-5.18.2.tar.!,
-    '5.18.0-RC4' => q!R/RJ/RJBS/perl-5.18.0-RC4.tar.!,
     '5.16.1' => q!R/RJ/RJBS/perl-5.16.1.tar.!,
     '5.12.5' => q!D/DO/DOM/perl-5.12.5.tar.!,
     '5.8.5'  => q!N/NW/NWCLARK/perl-5.8.5.tar.!,


### PR DESCRIPTION
Because old RC versions were removed.

There is no appropriate RC version like 5.24-RC now if RC versions <= 22 are removed.
This is related to #53.