### PR TITLE
regexp to extract basename fails if path contains 'bin' more than once

### DIFF
--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -372,7 +372,7 @@ sub symlink_devel_executables {
     my ($class, $bin_dir) = @_;
 
     for my $executable (glob("$bin_dir/*")) {
-        my ($name, $version) = $executable =~ m/bin\/(.+?)(5\.\d.*)?$/;
+        my ($name, $version) = basename( $executable ) =~ m/(.+?)(5\.\d.*)?$/;
         if ($version) {
             my $cmd = "ln -fs $executable $bin_dir/$name";
             $class->info($cmd);


### PR DESCRIPTION
if $bin_dir contains the 'bin' string more than once, e.g.

  /home/axafbin/.plenv/versions/5.22.2/bin/

it will extract the wrong substring.  Instead, use File::Basename::basename().