### PR TITLE
use metacpan to find perl releases instead of cpansearch

### DIFF
--- a/author/fatpack.sh
+++ b/author/fatpack.sh
@@ -9,7 +9,7 @@ plenv install-cpanm
 cpanm Test::More
 cpanm Perl::Strip
 cpanm App::FatPacker
-cpanm CPAN::Perl::Releases File::pushd HTTP::Tiny Devel::PatchPerl File::Temp Getopt::Long Pod::Usage
+cpanm CPAN::Perl::Releases File::pushd HTTP::Tiny JSON::PP Devel::PatchPerl File::Temp Getopt::Long Pod::Usage
 
 fatpack trace $SRC
 fatpack packlists-for `cat fatpacker.trace` >packlists

--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl' => '5.008002';
 requires 'CPAN::Perl::Releases' => '0';
 requires 'File::pushd' => '0';
 requires 'HTTP::Tiny' => '0';
+requires 'JSON::PP' => '0';
 requires 'Devel::PatchPerl' => '0.88';
 requires 'File::Temp';
 requires 'Getopt::Long';

--- a/t/02_perl_release.t
+++ b/t/02_perl_release.t
@@ -30,11 +30,11 @@ subtest 'perl-releases-page' => sub {
     }
 };
 
-subtest 'search.cpan.org' => sub {
+subtest 'metacpan.org' => sub {
     plan skip_all => 'author test only' unless $ENV{AUTHOR_TESTING};
     my $tiny = HTTP::Tiny->new(timeout=>5);
-    my $res = $tiny->get("http://search.cpan.org/");
-    plan skip_all => 'search.cpan.org seems to be down' unless $res->{success};
+    my $res = $tiny->get("https://fastapi.metacpan.org/");
+    plan skip_all => 'fastapi.metacpan.org seems to be down' unless $res->{success};
     local $Perl::Build::CPAN_MIRROR = '';
     no warnings 'redefine';
     *{CPAN::Perl::Releases::perl_tarballs} = sub {};


### PR DESCRIPTION
See https://log.perl.org/2018/05/goodbye-search-dot-cpan-dot-org.html