### PR TITLE
Support latest minilla

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -14,11 +14,35 @@ use File::Basename;
 use File::Spec;
 
 my %args = (
-    license              => 'perl',
+    license              => 'perl_5',
     dynamic_config       => 0,
 
     configure_requires => {
-        'Module::Build' => 0.38,
+        'Module::Build' => '0.4005',
+    },
+
+    requires => {
+        'CPAN::Perl::Releases' => '0',
+        'Devel::PatchPerl' => '0.88',
+        'File::Temp' => '0',
+        'File::pushd' => '0',
+        'Getopt::Long' => '0',
+        'HTTP::Tiny' => '0',
+        'Pod::Usage' => '1.63',
+        'perl' => '5.008002',
+    },
+
+    recommends => {
+    },
+
+    suggests => {
+    },
+
+    build_requires => {
+    },
+
+    test_requires => {
+        'Test::More' => '0.98',
     },
 
     name            => 'Perl-Build',
@@ -50,16 +74,4 @@ my $builder = Module::Build->subclass(
     }
 )->new(%args);
 $builder->create_build_script();
-
-use File::Copy;
-
-print "cp META.json MYMETA.json\n";
-copy("META.json","MYMETA.json") or die "Copy failed(META.json): $!";
-
-if (-f 'META.yml') {
-    print "cp META.yml MYMETA.yml\n";
-    copy("META.yml","MYMETA.yml") or die "Copy failed(META.yml): $!";
-} else {
-    print "There is no META.yml... You may install this module from the repository...\n";
-}
 

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Tokuhiro Matsuno <tokuhirom@gmail.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v2.5.0, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.0.9, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -28,7 +28,7 @@
    "prereqs" : {
       "configure" : {
          "requires" : {
-            "Module::Build" : "0.38"
+            "Module::Build" : "0.4005"
          }
       },
       "develop" : {
@@ -83,14 +83,16 @@
       "hagihala <hagihala@hatena.ne.jp>",
       "Tony <zearin@gonk.net>",
       "Przemysław Wesołek <jest@go.art.pl>",
-      "Kenichi Ishigaki <ishigaki@cpan.org>",
       "Masahiro Nagano <kazeburo@gmail.com>",
-      "Shoichi Kaji <skaji@cpan.org>",
       "Tatsuhiko Miyagawa <miyagawa@bulknews.net>",
       "moznion <moznion@gmail.com>",
       "Ashley Hindmarsh <ash+github@best-scarper.co.uk>",
+      "Tatsuhiko Miyagawa <miyagawa@gmail.com>",
+      "Diab Jerius <djerius@cfa.harvard.edu>",
       "Syohei YOSHIDA <syohex@gmail.com>",
-      "Tatsuhiko Miyagawa <miyagawa@gmail.com>"
+      "Kenichi Ishigaki <ishigaki@cpan.org>",
+      "Mitch McCracken <mrmccrac@gmail.com>",
+      "Shoichi Kaji <skaji@cpan.org>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.27300"
+   "x_serialization_backend" : "JSON::PP version 2.27400"
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Perl::Build - perl builder
 # CLI interface without dependencies
 
     # perl-build command is FatPacker ready
-    % curl https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build | perl - 5.16.2 /opt/perl-5.16/
+    % curl -L https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build | perl - 5.16.2 /opt/perl-5.16/
 
 # CLI interface
 
@@ -159,7 +159,7 @@ Thanks
 
 # AUTHOR
 
-Tokuhiro Matsuno &lt;tokuhirom@gmail.com>
+Tokuhiro Matsuno <tokuhirom@gmail.com>
 
 # LICENSE
 

--- a/minil.toml
+++ b/minil.toml
@@ -1,3 +1,5 @@
+module_maker="ModuleBuild"
+
 [FileGatherer]
 exclude_match = [
     '^perl-build$'


### PR DESCRIPTION
latest Minilla uses Module::Build::Tiny as a default module builder. we need to specify Module::Builder immediately.