### PR TITLE
no need to use lib "lib"

### DIFF
--- a/bin/plenv-install
+++ b/bin/plenv-install
@@ -22,7 +22,6 @@ use strict;
 use warnings;
 use 5.008001;
 use FindBin;
-use lib "$FindBin::Bin/../lib/";
 
 use Getopt::Long ();
 use File::Path qw(mkpath);

--- a/script/perl-build
+++ b/script/perl-build
@@ -1,8 +1,6 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use FindBin;
-use lib "$FindBin::Bin/../lib/";
 use Perl::Build;
 use Getopt::Long;
 use Pod::Usage;


### PR DESCRIPTION
Because we fatpack `lib/**/*.pm` files, we do not need to use lib "lib".