### PR TITLE
perl 5.8.2 -> 5.8.1

### DIFF
--- a/author/fatpack.pl
+++ b/author/fatpack.pl
@@ -30,7 +30,7 @@ Getopt::Long::GetOptions
     "h|help" => sub { exec "perldoc", $0 },
 or exit 1;
 
-my $target = '5.8.2';
+my $target = '5.8.1';
 
 my $resolver = -f "cpanfile.snapshot" && !$update ? "snapshot" : "metadb";
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl' => '5.008002';
+requires 'perl' => '5.008001';
 requires 'CPAN::Perl::Releases' => '3.58';
 requires 'CPAN::Perl::Releases::MetaCPAN' => '0.006';
 requires 'File::pushd' => '0';

--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
-use 5.008002;
+use 5.008001;
 our $VERSION = '1.20';
 
 use Carp ();

--- a/lib/Perl/Build/Built.pm
+++ b/lib/Perl/Build/Built.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use utf8;
 
-use 5.008002;
+use 5.008001;
 our $VERSION = '1.20';
 
 use Carp ();


### PR DESCRIPTION
* Lancaster Consensus says the Perl toolchain will target Perl 5.8.1
* Perl-Build works fine with 5.8.1 without any modification

So I think it is worth to lower perl requirement.