### PR TITLE
silence "Use of uninitialized value"

### DIFF
--- a/lib/Perl/Build/Built.pm
+++ b/lib/Perl/Build/Built.pm
@@ -24,8 +24,9 @@ sub run_env {
               . ' or ->run_env(\&code)'
               . ' or ->run_env(\%config)' );
     }
-    local $ENV{PATH}    = $self->combined_bin_path;
-    local $ENV{MANPATH} = $self->combined_man_path;
+    local $ENV{PATH} = $self->combined_bin_path;
+    my $combined_man_path = $self->combined_man_path;
+    local $ENV{MANPATH} = $combined_man_path if $combined_man_path;
     delete local $ENV{PERL5LIB};
     return $config->{code}->();
 }


### PR DESCRIPTION
Silence the following warning.
```
❯ perl -v
This is perl, v5.8.8 built for darwin-2level

❯ prove -l t/01_perl_build_built.t
t/01_perl_build_built.t .. 1/? Use of uninitialized value in scalar assignment at /Users/skaji/src/github.com/tokuhirom/Perl-Build/lib/Perl/Build/Built.pm line 28.
t/01_perl_build_built.t .. ok
All tests successful.
Files=1, Tests=7,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.05 cusr  0.01 csys =  0.07 CPU)
Result: PASS
```