### PR TITLE
fatpack EUMM for centos

### DIFF
--- a/author/cpanfile.snapshot
+++ b/author/cpanfile.snapshot
@@ -53,6 +53,51 @@ DISTRIBUTIONS
     requirements:
       Carp 1.05
       ExtUtils::MakeMaker 0
+  ExtUtils-MakeMaker-7.34
+    pathname: B/BI/BINGOS/ExtUtils-MakeMaker-7.34.tar.gz
+    provides:
+      ExtUtils::Command 7.34
+      ExtUtils::Command::MM 7.34
+      ExtUtils::Liblist 7.34
+      ExtUtils::Liblist::Kid 7.34
+      ExtUtils::MM 7.34
+      ExtUtils::MM_AIX 7.34
+      ExtUtils::MM_Any 7.34
+      ExtUtils::MM_BeOS 7.34
+      ExtUtils::MM_Cygwin 7.34
+      ExtUtils::MM_DOS 7.34
+      ExtUtils::MM_Darwin 7.34
+      ExtUtils::MM_MacOS 7.34
+      ExtUtils::MM_NW5 7.34
+      ExtUtils::MM_OS2 7.34
+      ExtUtils::MM_QNX 7.34
+      ExtUtils::MM_UWIN 7.34
+      ExtUtils::MM_Unix 7.34
+      ExtUtils::MM_VMS 7.34
+      ExtUtils::MM_VOS 7.34
+      ExtUtils::MM_Win32 7.34
+      ExtUtils::MM_Win95 7.34
+      ExtUtils::MY 7.34
+      ExtUtils::MakeMaker 7.34
+      ExtUtils::MakeMaker::Config 7.34
+      ExtUtils::MakeMaker::Locale 7.34
+      ExtUtils::MakeMaker::_version 7.34
+      ExtUtils::MakeMaker::charstar 7.34
+      ExtUtils::MakeMaker::version 7.34
+      ExtUtils::MakeMaker::version::regex 7.34
+      ExtUtils::MakeMaker::version::vpp 7.34
+      ExtUtils::Mkbootstrap 7.34
+      ExtUtils::Mksymlists 7.34
+      ExtUtils::testlib 7.34
+      MM 7.34
+      MY 7.34
+    requirements:
+      Data::Dumper 0
+      Encode 0
+      File::Basename 0
+      File::Spec 0.8
+      Pod::Man 0
+      perl 5.006
   File-Which-1.22
     pathname: P/PL/PLICEASE/File-Which-1.22.tar.gz
     provides:

--- a/author/fatpack.pl
+++ b/author/fatpack.pl
@@ -36,6 +36,7 @@ my $resolver = -f "cpanfile.snapshot" && !$update ? "snapshot" : "metadb";
 
 warn "Resolver $resolver\n";
 cpm "install", "--cpanfile", "../cpanfile", "--target-perl", $target, "--resolver", $resolver;
+cpm "install", "--resolver", $resolver, "--reinstall", "ExtUtils::MakeMaker";
 gen_snapshot if $update;
 print STDERR "FatPacking...";
 fatpack


### PR DESCRIPTION
Fix #82 

On CentOS 6 and 7, `yum install perl` does not install ExtUtils::MakeMaker.
On the other hand, Devel::PatchPerl uses ExtUtils::MakeMaker.
https://github.com/bingos/devel-patchperl/blob/95826fad7e96f573dad727374cfb9f4a8b1017ee/lib/Devel/PatchPerl.pm#L345

This PR adds ExtUtils::MakeMaker in fatpacked script.