### PR TITLE
dump response body if http status = 599

### DIFF
--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -127,7 +127,9 @@ sub http_get {
     if ($response->{success}) {
         return $response->{content};
     } else {
-        die "Cannot get content from $url: $response->{status} $response->{reason}\n";
+        my $msg = $response->{status} == 599 ? ", $response->{content}" : "";
+        chomp $msg;
+        die "Cannot get content from $url: $response->{status} $response->{reason}$msg\n";
     }
 }
 
@@ -139,7 +141,9 @@ sub http_mirror {
     if ($response->{success}) {
         print "Downloaded $url to $path.\n";
     } else {
-        die "Cannot get file from $url: $response->{status} $response->{reason}";
+        my $msg = $response->{status} == 599 ? ", $response->{content}" : "";
+        chomp $msg;
+        die "Cannot get file from $url: $response->{status} $response->{reason}$msg";
     }
 }
 


### PR DESCRIPTION
before
```
❯ /usr/bin/perl ./perl-build 5.28.0 foo
Fetching 5.28.0 as /var/folders/9j/xylqh05507j22rcpxpfxr2mw0000gn/T/bMT4NlTIgW/perl-5.28.0.tar.gz (https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0.tar.gz)
Cannot get file from https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0.tar.gz: 599 Internal Exception at ./perl-build line 10353.
```

after
```
❯ /usr/bin/perl ./perl-build 5.28.0 foo
Fetching 5.28.0 as /var/folders/9j/xylqh05507j22rcpxpfxr2mw0000gn/T/O3qNLGWP4C/perl-5.28.0.tar.gz (https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0.tar.gz)
Cannot get file from https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/perl-5.28.0.tar.gz: 599 Internal Exception, Can't verify SSL peers without knowing which Certificate Authorities to trust

This problem can be fixed by either setting the PERL_LWP_SSL_CA_FILE
envirionment variable or by installing the Mozilla::CA module.

To disable verification of SSL peers set the PERL_LWP_SSL_VERIFY_HOSTNAME
envirionment variable to 0.  If you do this you can't be sure that you
communicate with the expected peer. at ./perl-build line 10353.
```