### PR TITLE
Allow installing from local tar.xz

### DIFF
--- a/script/perl-build
+++ b/script/perl-build
@@ -86,7 +86,7 @@ if ($stuff eq 'blead') {
             tarball_dir       => $tarball_dir,
         )
     );
-} elsif ($stuff =~ /\.(gz|bz2)$/) {
+} elsif ($stuff =~ /\.(gz|bz2|xz)$/) {
     Perl::Build->install_from_tarball(
         $stuff => (
             dst_path          => $dest,


### PR DESCRIPTION
Currently if you pass a path to a .tar.xz file it will fallback to assuming it is a perl version to look up.