### PR TITLE
use https explicitly for installing blead perl

### DIFF
--- a/script/perl-build
+++ b/script/perl-build
@@ -64,7 +64,7 @@ push @configure_options, "-Dman1dir=none", "-Dman3dir=none" if $noman;
 $ENV{PERL5_PATCHPERL_PLUGIN} = $patches if defined $patches;
 
 if ($stuff eq 'blead') {
-    my $url = "http://perl5.git.perl.org/perl.git/snapshot/blead.tar.gz";
+    my $url = "https://perl5.git.perl.org/perl.git/snapshot/blead.tar.gz";
     Perl::Build->install_from_url(
         $url => (
             dst_path          => $dest,


### PR DESCRIPTION
When requesting the URL `http://perl5.git.perl.org/perl.git/snapshot/blead.tar.gz` for blead perl, it is redirected to an `https` URL. This is a problem because HTTP::Tinyish uses the original URL to determine whether it needs to find a user agent with HTTPS support, so it may select one without that support and then fail because of the redirect.