### PR TITLE
Use github for blead archive

### DIFF
--- a/script/perl-build
+++ b/script/perl-build
@@ -64,7 +64,7 @@ push @configure_options, "-Dman1dir=none", "-Dman3dir=none" if $noman;
 $ENV{PERL5_PATCHPERL_PLUGIN} = $patches if defined $patches;
 
 if ($stuff eq 'blead') {
-    my $url = "https://perl5.git.perl.org/perl.git/snapshot/blead.tar.gz";
+    my $url = "https://github.com/Perl/perl5/archive/blead.tar.gz";
     Perl::Build->install_from_url(
         $url => (
             dst_path          => $dest,


### PR DESCRIPTION
Fixes #94 

perl5.git.perl.org is likely going to be retired soon, so this updates Perl::Build to use github to fetch the blead archive.  The archive from GitHub has a different name for the top level directory, so the code has been refactored to cope with any top level directory.  This removes the need for the blead and cperl special cases.

This can't be merged until Perl/perl5#17199 or something similar is merged into perl core.