### PR TITLE
Improve installing from Github

### DIFF
--- a/bin/plenv-install
+++ b/bin/plenv-install
@@ -83,6 +83,32 @@ sub main {
         die "$prefix is already installed\n";
     }
 
+    # If we're going to attempt to install from github
+    # we need to know the "calculated" name.
+    # We optimize slightly by making sure $as matches $definition
+    # and doesn't look like any of the things that are likely to
+    # mean we are going to install from somewhere else.
+    if ( $as eq $definition && $as !~ m{^\d|://|\.(?:gz|bz2|xz)$} ) {
+        my $name;
+        my $pid = open my $fh, '-|' // die $!;
+        if ( !$pid ) {
+            open STDERR, '>/dev/null';
+            exec $^X, '--', $PERL_BUILD, '--github-name', $definition;
+            exit 255;
+        }
+        ($name) = readline $fh;
+        close $fh;
+        waitpid $pid, 0;
+
+        if ($name) {
+            chomp $name;
+            my $prefix = "$ENV{PLENV_ROOT}/versions/$name";
+            if ( -d $prefix ) {
+                die "$prefix is already installed\n";
+            }
+        }
+    }
+
     my $cache_dir = "$ENV{PLENV_ROOT}/cache/";
     mkpath($cache_dir);
     my $build_dir = "$ENV{PLENV_ROOT}/build/" . time . ".$$/";

--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -195,7 +195,8 @@ sub install_from_cpan {
         || ['-de'];
 
     # download tar ball
-    my ($dist_tarball, $dist_tarball_url) = Perl::Build->perl_release($version);
+    my ( $dist_tarball, $dist_tarball_url )
+        = ref $version ? @{$version} : Perl::Build->perl_release($version);
     my $dist_tarball_path = catfile($tarball_dir, $dist_tarball);
     if (-f $dist_tarball_path) {
         print "Use the previously fetched ${dist_tarball}\n";

--- a/script/perl-build
+++ b/script/perl-build
@@ -66,19 +66,7 @@ push @configure_options, "-Dman1dir=none", "-Dman3dir=none" if $noman;
 
 $ENV{PERL5_PATCHPERL_PLUGIN} = $patches if defined $patches;
 
-if ($stuff eq 'blead') {
-    my $url = "https://github.com/Perl/perl5/archive/blead.tar.gz";
-    Perl::Build->install_from_url(
-        $url => (
-            dst_path          => $dest,
-            configure_options => ['-Dusedevel', @configure_options],
-            test              => $test,
-            build_dir         => $build_dir,
-            jobs              => $jobs,
-            tarball_dir       => $tarball_dir,
-        )
-    );
-} elsif ($stuff =~ m{^https?://}) {
+if ($stuff =~ m{^https?://}) {
     Perl::Build->install_from_url(
         $stuff => (
             dst_path          => $dest,
@@ -100,17 +88,38 @@ if ($stuff eq 'blead') {
         )
     );
 } else {
-    my $version = $stuff;
-    Perl::Build->install_from_cpan(
-        $version => (
-            dst_path          => $dest,
-            configure_options => \@configure_options,
-            test              => $test,
-            build_dir         => $build_dir,
-            jobs              => $jobs,
-            tarball_dir       => $tarball_dir,
-        )
-    );
+    my $version;
+    {
+        local $@;
+        $version = eval { [ Perl::Build->perl_release($stuff) ] };
+        die if $@ and $@ !~ /ERROR: Cannot find the tarball/;
+    }
+    if ($version) {
+        Perl::Build->install_from_cpan(
+            $version => (
+                dst_path          => $dest,
+                configure_options => \@configure_options,
+                test              => $test,
+                build_dir         => $build_dir,
+                jobs              => $jobs,
+                tarball_dir       => $tarball_dir,
+            )
+        );
+    } else {
+        my ($url, $name) = Perl::Build->perl_release_by_github($stuff);
+        $dest =~ s/\Q$stuff\E$/$name/;
+
+        Perl::Build->install_from_url(
+            $url => (
+                dst_path          => $dest,
+                configure_options => ['-Dusedevel', @configure_options],
+                test              => $test,
+                build_dir         => $build_dir,
+                jobs              => $jobs,
+                tarball_dir       => $tarball_dir,
+            )
+        );
+    }
 }
 
 if ($symlink_devel_executables) {
@@ -136,10 +145,21 @@ perl-build - perl binary builder
     # And run it.
     % perl-build 5.16.2 /usr/local/perl-5.16.2
     % perl-build path/to/perl-5.16.2.tar.gz /usr/local/perl-5.16.2
+    % perl-build blead path/to/blead # install to path/to/blead-$commit_date
+    % perl-build smoke-me/now smoke-me/now # install to ./smoke-me_now-$commit_date
+    % perl-build 29c6c804 29c6c804 # install to ./$full_hash
+    % perl-build perl-1.0 perl-1.0 # install to ./perl-1.0-19871218000000
+         # ^ won't actuall work, as Devel::PatchPerl gets confused
 
 =head1 DESCRIPTION
 
 This script fetch/build/install perl5 from CPAN or tar ball.
+
+It will also install directly from Github.
+You can specify a branch, a C<branch@{date}>, or other "committish"
+that the Github API recognizes.
+If you do this and the end of the destination path matches the committish,
+it will calculate a name for the requested perl and replace that tail.
 
 =head1 OPTIONS
 

--- a/script/perl-build
+++ b/script/perl-build
@@ -26,6 +26,7 @@ GetOptions(
     'definitions' => \my $definitions,
     'patches=s' => \$patches,
     'build-dir=s' => \$build_dir,
+    'github-name' => \my $github_name,
     'j|jobs=i' => \my $jobs,
     'tarball-dir=s' => \my $tarball_dir,
     'version' => \my $show_version,
@@ -53,6 +54,13 @@ if ($definitions) {
 }
 
 shift @ARGV if @ARGV >= 1 && $ARGV[0] eq '--';
+
+if ($github_name) {
+    my $stuff = shift @ARGV || pod2usage();
+    my (undef, $name) = Perl::Build->perl_release_by_github($stuff);
+    print "$name\n";
+    exit;
+}
 
 my $stuff   = shift @ARGV or pod2usage();
 my $dest    = shift @ARGV or pod2usage();


### PR DESCRIPTION
This means you can not only `plenv install blead` but also `plenv install blead@{2001-02-03}` or [`plenv install 41b10d901d`](https://github.com/Perl/perl5/tree/41b10d901d) as well as [`plenv install leont/shutdownhook`](https://github.com/Perl/perl5/tree/leont/shutdownhook).  Unfortunately it doesn't work for pull-requests, but that could be added.  