### PR TITLE
use https for github urls

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Tokuhiro Matsuno <tokuhirom@gmail.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.1.11, CPAN::Meta::Converter version 2.150010",
+   "generated_by" : "Minilla/v3.1.17, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -68,7 +68,7 @@
       "homepage" : "https://github.com/tokuhirom/Perl-Build",
       "repository" : {
          "type" : "git",
-         "url" : "git://github.com/tokuhirom/Perl-Build.git",
+         "url" : "https://github.com/tokuhirom/Perl-Build.git",
          "web" : "https://github.com/tokuhirom/Perl-Build"
       }
    },

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Perl::Build - perl builder
 
 # Install as plenv plugin (Recommended)
 
-    % git clone git://github.com/tokuhirom/Perl-Build.git $(plenv root)/plugins/perl-build/
+    % git clone https://github.com/tokuhirom/Perl-Build.git $(plenv root)/plugins/perl-build/
 
 # CLI interface without dependencies
 

--- a/lib/Perl/Build.pm
+++ b/lib/Perl/Build.pm
@@ -357,7 +357,7 @@ Perl::Build - perl builder
 
 =head1 Install as plenv plugin (Recommended)
 
-    % git clone git://github.com/tokuhirom/Perl-Build.git $(plenv root)/plugins/perl-build/
+    % git clone https://github.com/tokuhirom/Perl-Build.git $(plenv root)/plugins/perl-build/
 
 =head1 CLI interface without dependencies
 


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/

GitHub disabled `git://` on March 15, 2022.
So let's use https:// instead.


fyi. <https://github.com/tokuhirom/Minilla/pull/315>